### PR TITLE
Feat Room db

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,4 +77,6 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.coil.compose)
     implementation(libs.material3)
+    implementation(libs.androidx.room.runtime)
+    implementation("com.google.code.gson:gson:2.10.1")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,19 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.0.0")
+    }
+}
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
+
+    id("kotlin-kapt")
     kotlin("plugin.serialization") version "2.1.10"
 }
 
@@ -15,10 +27,29 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary = true
+        }
+    }
+
+    // Использование annotationProcessorOptions с правильным синтаксисом
+    buildFeatures {
+        compose = true
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
+    kapt {
+        arguments {
+            arg("room.schemaLocation", "$projectDir/schemas")
         }
     }
 
@@ -31,19 +62,11 @@ android {
             )
         }
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    buildFeatures {
-        compose = true
-    }
+
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"
     }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -79,4 +102,6 @@ dependencies {
     implementation(libs.material3)
     implementation(libs.androidx.room.runtime)
     implementation("com.google.code.gson:gson:2.10.1")
+    implementation("androidx.room:room-ktx:2.4.0-rc01")
+    kapt("androidx.room:room-compiler:2.4.0-rc01")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
     <application
+        android:name=".AppContext"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.Pizzashift2025">
+            android:theme="@style/Theme.Pizzashift2025"
+            android:background="@android:color/white">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/pizza_shift_2025/AppContext.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/AppContext.kt
@@ -1,0 +1,20 @@
+package com.example.pizza_shift_2025
+
+import android.app.Application
+import android.content.Context
+
+class AppContext : Application() {
+
+    companion object {
+        lateinit var instance: AppContext
+            private set
+
+        val context: Context
+            get() = instance.applicationContext
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+    }
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/MainActivity.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/MainActivity.kt
@@ -12,9 +12,14 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.navigation.compose.rememberNavController
+import com.example.pizza_shift_2025.data.mapper.PizzaMapper
 import com.example.pizza_shift_2025.data.network.PizzaApi
+import com.example.pizza_shift_2025.data.repository.BasketRepositoryImpl
 import com.example.pizza_shift_2025.data.repository.PizzaRepositoryImpl
+import com.example.pizza_shift_2025.domain.repository.BasketRepository
 import com.example.pizza_shift_2025.domain.repository.PizzaRepository
+import com.example.pizza_shift_2025.domain.usecase.AddPizzaToBasketUseCase
+import com.example.pizza_shift_2025.domain.usecase.GetBasketUseCase
 import com.example.pizza_shift_2025.domain.usecase.GetPizzaCatalogUseCase
 import com.example.pizza_shift_2025.presentation.navigation.MainScreen
 import com.example.pizza_shift_2025.presentation.ui.BottomNavigationBar
@@ -23,8 +28,12 @@ import com.example.pizza_shift_2025.ui.theme.Pizzashift2025Theme
 class MainActivity : ComponentActivity() {
     private val networkModule = NetworkModule()
     private val pizzaApi: PizzaApi = networkModule.retrofit.create(PizzaApi::class.java)
+    private val dbMapper: PizzaMapper = PizzaMapper()
+    private val BasketRepository: BasketRepository = BasketRepositoryImpl(pizzaApi, dbMapper)
     private val pizzaRepository: PizzaRepository = PizzaRepositoryImpl(pizzaApi)
     private val getPizzaCatalogUseCase: GetPizzaCatalogUseCase = GetPizzaCatalogUseCase(pizzaRepository)
+    private val getBasketUseCase: GetBasketUseCase = GetBasketUseCase(BasketRepository)
+    private val addPizzaToBasketUseCase: AddPizzaToBasketUseCase = AddPizzaToBasketUseCase(BasketRepository)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -43,6 +52,8 @@ class MainActivity : ComponentActivity() {
                 ) { innerPadding ->
                     MainScreen(
                         getPizzaCatalogUseCase,
+                        getBasketUseCase,
+                        addPizzaToBasketUseCase,
                         modifier = Modifier.padding(innerPadding).background(Color.White),
                         navController = navController
                     )

--- a/app/src/main/java/com/example/pizza_shift_2025/MainActivity.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/MainActivity.kt
@@ -4,10 +4,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.navigation.compose.rememberNavController
 import com.example.pizza_shift_2025.data.network.PizzaApi
 import com.example.pizza_shift_2025.data.repository.PizzaRepositoryImpl
@@ -27,7 +30,8 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            Pizzashift2025Theme {
+
+            Pizzashift2025Theme{
                 val navController = rememberNavController()
                 Scaffold(
                     modifier = Modifier.fillMaxSize(),
@@ -39,7 +43,7 @@ class MainActivity : ComponentActivity() {
                 ) { innerPadding ->
                     MainScreen(
                         getPizzaCatalogUseCase,
-                        modifier = Modifier.padding(innerPadding),
+                        modifier = Modifier.padding(innerPadding).background(Color.White),
                         navController = navController
                     )
                 }

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dao/BasketDao.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dao/BasketDao.kt
@@ -1,0 +1,18 @@
+package com.example.pizza_shift_2025.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Upsert
+import com.example.pizza_shift_2025.data.dbentity.PizzaEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PizzaDao {
+    @Insert
+    suspend fun insert(pizza: PizzaEntity)
+
+    @Query("SELECT * FROM pizza")
+    suspend fun getAllPizzas(): List<PizzaEntity>
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dao/BasketDao.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dao/BasketDao.kt
@@ -14,5 +14,5 @@ interface PizzaDao {
     suspend fun insert(pizza: PizzaEntity)
 
     @Query("SELECT * FROM pizza")
-    suspend fun getAllPizzas(): List<PizzaEntity>
+    suspend fun getBasket(): List<PizzaEntity>
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dao/PizzaDao.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dao/PizzaDao.kt
@@ -1,18 +1,18 @@
 package com.example.pizza_shift_2025.data.dao
 
+import android.util.Log
 import androidx.room.Dao
-import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
-import androidx.room.Upsert
 import com.example.pizza_shift_2025.data.dbentity.PizzaEntity
 import kotlinx.coroutines.flow.Flow
+
 
 @Dao
 interface PizzaDao {
     @Insert
-    suspend fun insert(pizza: PizzaEntity)
+    fun insert(pizza: PizzaEntity)
 
     @Query("SELECT * FROM pizza")
-    suspend fun getBasket(): List<PizzaEntity>
+    fun getBasket():  Flow<List<PizzaEntity>>
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/data/database/PizzaDataBase.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/database/PizzaDataBase.kt
@@ -5,6 +5,7 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import com.example.pizza_shift_2025.AppContext
 import com.example.pizza_shift_2025.data.dao.PizzaDao
 import com.example.pizza_shift_2025.data.dbconverter.DoughConverter
 import com.example.pizza_shift_2025.data.dbconverter.PizzaConverter
@@ -27,7 +28,7 @@ abstract class PizzaDataBase : RoomDatabase() {
             }
             synchronized(this){
                 val instance = Room.databaseBuilder(
-                    context.applicationContext,
+                    AppContext.context,
                     PizzaDataBase::class.java,
                     "movie_database"
                 ).build()

--- a/app/src/main/java/com/example/pizza_shift_2025/data/database/PizzaDataBase.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/database/PizzaDataBase.kt
@@ -13,7 +13,7 @@ import com.example.pizza_shift_2025.data.dbconverter.SizeConverter
 import com.example.pizza_shift_2025.data.dbentity.PizzaEntity
 
 @Database(entities = [PizzaEntity::class],
-    version = 1)
+    version = 2)
 @TypeConverters(PizzaConverter::class, SizeConverter::class, DoughConverter::class)
 abstract class PizzaDataBase : RoomDatabase() {
     abstract fun PizzaDao(): PizzaDao
@@ -28,10 +28,10 @@ abstract class PizzaDataBase : RoomDatabase() {
             }
             synchronized(this){
                 val instance = Room.databaseBuilder(
-                    AppContext.context,
+                    context.applicationContext,
                     PizzaDataBase::class.java,
-                    "movie_database"
-                ).build()
+                    "pizza_database"
+                ).fallbackToDestructiveMigration().build()
                 INSTANCE = instance
                 return instance
             }

--- a/app/src/main/java/com/example/pizza_shift_2025/data/database/PizzaDataBase.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/database/PizzaDataBase.kt
@@ -1,0 +1,40 @@
+package com.example.pizza_shift_2025.data.database
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.example.pizza_shift_2025.data.dao.PizzaDao
+import com.example.pizza_shift_2025.data.dbconverter.DoughConverter
+import com.example.pizza_shift_2025.data.dbconverter.PizzaConverter
+import com.example.pizza_shift_2025.data.dbconverter.SizeConverter
+import com.example.pizza_shift_2025.data.dbentity.PizzaEntity
+
+@Database(entities = [PizzaEntity::class],
+    version = 1)
+@TypeConverters(PizzaConverter::class, SizeConverter::class, DoughConverter::class)
+abstract class PizzaDataBase : RoomDatabase() {
+    abstract fun PizzaDao(): PizzaDao
+
+    companion object{
+        @Volatile
+        private var INSTANCE: PizzaDataBase? = null
+        fun getDatabase(context: Context): PizzaDataBase{
+            val tempInstance = INSTANCE
+            if (tempInstance != null){
+                return tempInstance
+            }
+            synchronized(this){
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    PizzaDataBase::class.java,
+                    "movie_database"
+                ).build()
+                INSTANCE = instance
+                return instance
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dbconverter/DoughConverter.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dbconverter/DoughConverter.kt
@@ -1,17 +1,18 @@
 package com.example.pizza_shift_2025.data.dbconverter
 
 import androidx.room.TypeConverter
+import com.example.pizza_shift_2025.data.dbentity.DoughEntity
 import com.example.pizza_shift_2025.domain.entity.Dough
 import com.google.gson.Gson
 
 class DoughConverter {
     @TypeConverter
-    fun fromDough(value: Dough): String {
-        return Gson().toJson(value)
+    fun fromDough(dough: DoughEntity): String {
+        return Gson().toJson(dough)
     }
 
     @TypeConverter
-    fun toDough(value: String): Dough {
-        return Gson().fromJson(value, Dough::class.java)
+    fun toDough(data: String): DoughEntity {
+        return Gson().fromJson(data, DoughEntity::class.java)
     }
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dbconverter/DoughConverter.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dbconverter/DoughConverter.kt
@@ -1,0 +1,17 @@
+package com.example.pizza_shift_2025.data.dbconverter
+
+import androidx.room.TypeConverter
+import com.example.pizza_shift_2025.domain.entity.Dough
+import com.google.gson.Gson
+
+class DoughConverter {
+    @TypeConverter
+    fun fromDough(value: Dough): String {
+        return Gson().toJson(value)
+    }
+
+    @TypeConverter
+    fun toDough(value: String): Dough {
+        return Gson().fromJson(value, Dough::class.java)
+    }
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dbconverter/PizzaConverter.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dbconverter/PizzaConverter.kt
@@ -8,13 +8,13 @@ import com.google.gson.reflect.TypeToken
 
 class PizzaConverter {
     @TypeConverter
-    fun fromToppingList(value: List<ToppingEntity>): String {
-        return Gson().toJson(value)
+    fun fromToppingList(toppings: List<ToppingEntity>): String {
+        return Gson().toJson(toppings)
     }
 
     @TypeConverter
-    fun toToppingList(value: String): List<ToppingEntity> {
+    fun toToppingList(data: String): List<ToppingEntity> {
         val listType = object : TypeToken<List<ToppingEntity>>() {}.type
-        return Gson().fromJson(value, listType)
+        return Gson().fromJson(data, listType)
     }
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dbconverter/PizzaConverter.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dbconverter/PizzaConverter.kt
@@ -1,0 +1,20 @@
+package com.example.pizza_shift_2025.data.dbconverter
+
+import androidx.room.TypeConverter
+import com.example.pizza_shift_2025.data.dbentity.ToppingEntity
+import com.example.pizza_shift_2025.domain.entity.Topping
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+class PizzaConverter {
+    @TypeConverter
+    fun fromToppingList(value: List<ToppingEntity>): String {
+        return Gson().toJson(value)
+    }
+
+    @TypeConverter
+    fun toToppingList(value: String): List<ToppingEntity> {
+        val listType = object : TypeToken<List<ToppingEntity>>() {}.type
+        return Gson().fromJson(value, listType)
+    }
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dbconverter/SizeConverter.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dbconverter/SizeConverter.kt
@@ -6,12 +6,12 @@ import com.google.gson.Gson
 
 class SizeConverter {
     @TypeConverter
-    fun fromSize(value: SizeEntity): String {
-        return Gson().toJson(value)
+    fun fromSize(size: SizeEntity): String {
+        return Gson().toJson(size)
     }
 
     @TypeConverter
-    fun toSize(value: String): SizeEntity {
-        return Gson().fromJson(value, SizeEntity::class.java)
+    fun toSize(data: String): SizeEntity {
+        return Gson().fromJson(data, SizeEntity::class.java)
     }
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dbconverter/SizeConverter.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dbconverter/SizeConverter.kt
@@ -1,0 +1,17 @@
+package com.example.pizza_shift_2025.data.dbconverter
+
+import androidx.room.TypeConverter
+import com.example.pizza_shift_2025.data.dbentity.SizeEntity
+import com.google.gson.Gson
+
+class SizeConverter {
+    @TypeConverter
+    fun fromSize(value: SizeEntity): String {
+        return Gson().toJson(value)
+    }
+
+    @TypeConverter
+    fun toSize(value: String): SizeEntity {
+        return Gson().fromJson(value, SizeEntity::class.java)
+    }
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dbentity/DoughEntity.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dbentity/DoughEntity.kt
@@ -1,0 +1,6 @@
+package com.example.pizza_shift_2025.data.dbentity
+
+data class DoughEntity(
+    val name: String,
+    val price: Int
+)

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dbentity/PizzaEntity.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dbentity/PizzaEntity.kt
@@ -1,0 +1,22 @@
+package com.example.pizza_shift_2025.data.dbentity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.TypeConverters
+import com.example.pizza_shift_2025.data.dbconverter.DoughConverter
+import com.example.pizza_shift_2025.data.dbconverter.PizzaConverter
+import com.example.pizza_shift_2025.data.dbconverter.SizeConverter
+
+@Entity(tableName = "Pizza")
+data class PizzaEntity(
+    @PrimaryKey val id: String,
+    val name: String,
+    val price: Int,
+    val description: String,
+    @TypeConverters(PizzaConverter::class)
+    val toppings: List<ToppingEntity>,
+    @TypeConverters(SizeConverter::class)
+    val size: SizeEntity,
+    @TypeConverters(DoughConverter::class)
+    val doughs: DoughEntity
+)

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dbentity/PizzaEntity.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dbentity/PizzaEntity.kt
@@ -7,11 +7,12 @@ import com.example.pizza_shift_2025.data.dbconverter.DoughConverter
 import com.example.pizza_shift_2025.data.dbconverter.PizzaConverter
 import com.example.pizza_shift_2025.data.dbconverter.SizeConverter
 
-@Entity(tableName = "Pizza")
+@Entity(tableName = "pizza")
 data class PizzaEntity(
     @PrimaryKey val id: String,
     val name: String,
     val price: Int,
+    val img: String,
     val description: String,
     @TypeConverters(PizzaConverter::class)
     val toppings: List<ToppingEntity>,

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dbentity/SizeEntity.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dbentity/SizeEntity.kt
@@ -1,0 +1,6 @@
+package com.example.pizza_shift_2025.data.dbentity
+
+data class SizeEntity(
+    val name: String,
+    val price: Int
+)

--- a/app/src/main/java/com/example/pizza_shift_2025/data/dbentity/ToppingEntity.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/dbentity/ToppingEntity.kt
@@ -1,0 +1,6 @@
+package com.example.pizza_shift_2025.data.dbentity
+
+data class ToppingEntity(
+    val name: String,
+    val cost: Int
+)

--- a/app/src/main/java/com/example/pizza_shift_2025/data/mapper/PizzaMapper.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/mapper/PizzaMapper.kt
@@ -11,14 +11,16 @@ import com.example.pizza_shift_2025.domain.entity.IngredientType
 import com.example.pizza_shift_2025.domain.entity.Pizza
 import com.example.pizza_shift_2025.domain.entity.Size
 import com.example.pizza_shift_2025.domain.entity.SizeType
+import java.util.UUID
 
 class PizzaMapper {
 
     fun toPizzaEntity(pizza: Pizza): PizzaEntity {
         return PizzaEntity(
-            id = pizza.id,
+            id = UUID.randomUUID().toString(),
             name = pizza.name,
             price = 0,
+            img = pizza.img,
             description = pizza.description,
             toppings = pizza.toppings.map { toToppingEntity(it) },
             size = toSizeEntity(pizza.sizes.first()),
@@ -58,7 +60,7 @@ class PizzaMapper {
             allergens = emptyList(),
             calories = 0,
             carbohydrates = "0g",
-            img = "",
+            img = pizzaEntity.img,
             ingredients = emptyList(),
             isGlutenFree = false,
             isHit = false,

--- a/app/src/main/java/com/example/pizza_shift_2025/data/mapper/PizzaMapper.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/mapper/PizzaMapper.kt
@@ -1,0 +1,94 @@
+package com.example.pizza_shift_2025.data.mapper
+
+import com.example.pizza_shift_2025.data.dbentity.DoughEntity
+import com.example.pizza_shift_2025.data.dbentity.PizzaEntity
+import com.example.pizza_shift_2025.data.dbentity.SizeEntity
+import com.example.pizza_shift_2025.data.dbentity.ToppingEntity
+import com.example.pizza_shift_2025.domain.entity.Dough
+import com.example.pizza_shift_2025.domain.entity.DoughType
+import com.example.pizza_shift_2025.domain.entity.Ingredient
+import com.example.pizza_shift_2025.domain.entity.IngredientType
+import com.example.pizza_shift_2025.domain.entity.Pizza
+import com.example.pizza_shift_2025.domain.entity.Size
+import com.example.pizza_shift_2025.domain.entity.SizeType
+
+class PizzaMapper {
+
+    fun toPizzaEntity(pizza: Pizza): PizzaEntity {
+        return PizzaEntity(
+            id = pizza.id,
+            name = pizza.name,
+            price = 0,
+            description = pizza.description,
+            toppings = pizza.toppings.map { toToppingEntity(it) },
+            size = toSizeEntity(pizza.sizes.first()),
+            doughs = toDoughEntity(pizza.doughs.first())
+        )
+    }
+
+    private fun toToppingEntity(ingredient: Ingredient): ToppingEntity {
+        return ToppingEntity(
+            name = ingredient.name.name,
+            cost = 0
+        )
+    }
+
+    private fun toSizeEntity(size: Size): SizeEntity {
+        return SizeEntity(
+            name = size.name.name,
+            price = 0
+        )
+    }
+
+    private fun toDoughEntity(dough: Dough): DoughEntity {
+        return DoughEntity(
+            name = dough.name.name,
+            price = 0
+        )
+    }
+
+    fun toPizza(pizzaEntity: PizzaEntity): Pizza {
+        return Pizza(
+            id = pizzaEntity.id,
+            name = pizzaEntity.name,
+            description = pizzaEntity.description,
+            toppings = pizzaEntity.toppings.map { toTopping(it) },
+            sizes = listOf(toSize(pizzaEntity.size)),
+            doughs = listOf(toDough(pizzaEntity.doughs)),
+            allergens = emptyList(),
+            calories = 0,
+            carbohydrates = "0g",
+            img = "",
+            ingredients = emptyList(),
+            isGlutenFree = false,
+            isHit = false,
+            isNew = false,
+            isVegetarian = false,
+            protein = "0g",
+            sodium = "0mg",
+            totalFat = "0g"
+        )
+    }
+
+    private fun toTopping(toppingEntity: ToppingEntity): Ingredient {
+        return Ingredient(
+            name = enumValueOf<IngredientType>(toppingEntity.name),
+            cost = toppingEntity.cost,
+            img = ""
+        )
+    }
+
+    private fun toSize(sizeEntity: SizeEntity): Size {
+        return Size(
+            name = enumValueOf<SizeType>(sizeEntity.name),
+            price = sizeEntity.price
+        )
+    }
+
+    private fun toDough(doughEntity: DoughEntity): Dough {
+        return Dough(
+            name = enumValueOf<DoughType>(doughEntity.name),
+            price = doughEntity.price
+        )
+    }
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/data/model/DoughModel.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/model/DoughModel.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class DoughModel(
     val name: DoughTypeModel,
-    val price: Double
+    val price: Int
 )

--- a/app/src/main/java/com/example/pizza_shift_2025/data/repository/BasketRepositoryImpl.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/repository/BasketRepositoryImpl.kt
@@ -16,7 +16,8 @@ class BasketRepositoryImpl (
         db.PizzaDao().insert(mapper.toPizzaEntity(pizza))
 
     override suspend fun getBasket(): List<Pizza> {
-        TODO("Not yet implemented")
+        val pizzaEntities = db.PizzaDao().getBasket()
+        return pizzaEntities.map { mapper.toPizza(it) }
     }
 
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/data/repository/BasketRepositoryImpl.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/repository/BasketRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.example.pizza_shift_2025.data.repository
+
+import com.example.pizza_shift_2025.AppContext
+import com.example.pizza_shift_2025.data.database.PizzaDataBase
+import com.example.pizza_shift_2025.data.mapper.PizzaMapper
+import com.example.pizza_shift_2025.data.network.PizzaApi
+import com.example.pizza_shift_2025.domain.entity.Pizza
+import com.example.pizza_shift_2025.domain.repository.BasketRepository
+
+class BasketRepositoryImpl (
+    private val pizzaApi: PizzaApi,
+    private val mapper: PizzaMapper
+) : BasketRepository{
+    val db = PizzaDataBase.getDatabase(AppContext.context)
+    override suspend fun addPizzaToBasket(pizza: Pizza) =
+        db.PizzaDao().insert(mapper.toPizzaEntity(pizza))
+
+    override suspend fun getBasket(): List<Pizza> {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/data/repository/BasketRepositoryImpl.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/repository/BasketRepositoryImpl.kt
@@ -1,23 +1,32 @@
 package com.example.pizza_shift_2025.data.repository
 
+import android.util.Log
 import com.example.pizza_shift_2025.AppContext
 import com.example.pizza_shift_2025.data.database.PizzaDataBase
 import com.example.pizza_shift_2025.data.mapper.PizzaMapper
 import com.example.pizza_shift_2025.data.network.PizzaApi
 import com.example.pizza_shift_2025.domain.entity.Pizza
 import com.example.pizza_shift_2025.domain.repository.BasketRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 
 class BasketRepositoryImpl (
     private val pizzaApi: PizzaApi,
     private val mapper: PizzaMapper
 ) : BasketRepository{
-    val db = PizzaDataBase.getDatabase(AppContext.context)
-    override suspend fun addPizzaToBasket(pizza: Pizza) =
-        db.PizzaDao().insert(mapper.toPizzaEntity(pizza))
-
-    override suspend fun getBasket(): List<Pizza> {
-        val pizzaEntities = db.PizzaDao().getBasket()
-        return pizzaEntities.map { mapper.toPizza(it) }
+    private val db = PizzaDataBase.getDatabase(AppContext.context.applicationContext)
+    override suspend fun addPizzaToBasket(pizza: Pizza) {
+        withContext(Dispatchers.IO) {
+            db.PizzaDao().insert(mapper.toPizzaEntity(pizza))
+        }
+    }
+    override fun getBasket(): Flow<List<Pizza>> {
+        return db.PizzaDao().getBasket().map { pizzaEntities ->
+            pizzaEntities.map { mapper.toPizza(it) }
+        }
     }
 
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/data/repository/PizzaRepositoruImpl.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/repository/PizzaRepositoruImpl.kt
@@ -9,7 +9,7 @@ import com.example.pizza_shift_2025.domain.repository.PizzaRepository
 class PizzaRepositoryImpl(
     private val pizzaApi: PizzaApi
 ): PizzaRepository {
-    override suspend fun getPizzaCatalog(): List<Pizza> {
-        return (pizzaApi.getPizzaCatalog().catalog.map { it.toDomainModel() })
-    }
+    override suspend fun getPizzaCatalog(): List<Pizza> =
+        (pizzaApi.getPizzaCatalog().catalog.map { it.toDomainModel() })
+
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/data/repository/PizzaRepositoruImpl.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/data/repository/PizzaRepositoruImpl.kt
@@ -11,5 +11,4 @@ class PizzaRepositoryImpl(
 ): PizzaRepository {
     override suspend fun getPizzaCatalog(): List<Pizza> =
         (pizzaApi.getPizzaCatalog().catalog.map { it.toDomainModel() })
-
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/domain/entity/Dough.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/domain/entity/Dough.kt
@@ -2,5 +2,5 @@ package com.example.pizza_shift_2025.domain.entity
 
 data class Dough(
     val name: DoughType,
-    val price: Double
+    val price: Int
 )

--- a/app/src/main/java/com/example/pizza_shift_2025/domain/repository/BasketRepository.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/domain/repository/BasketRepository.kt
@@ -1,8 +1,9 @@
 package com.example.pizza_shift_2025.domain.repository
 
 import com.example.pizza_shift_2025.domain.entity.Pizza
+import kotlinx.coroutines.flow.Flow
 
 interface BasketRepository {
     suspend fun addPizzaToBasket(pizza: Pizza)
-    suspend fun getBasket() : List<Pizza>
+    fun getBasket() : Flow<List<Pizza>>
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/domain/repository/BasketRepository.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/domain/repository/BasketRepository.kt
@@ -1,0 +1,8 @@
+package com.example.pizza_shift_2025.domain.repository
+
+import com.example.pizza_shift_2025.domain.entity.Pizza
+
+interface BasketRepository {
+    suspend fun addPizzaToBasket(pizza: Pizza)
+    suspend fun getBasket() : List<Pizza>
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/domain/usecase/AddPizzaToBasketUseCase.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/domain/usecase/AddPizzaToBasketUseCase.kt
@@ -1,0 +1,10 @@
+package com.example.pizza_shift_2025.domain.usecase
+
+import com.example.pizza_shift_2025.domain.entity.Pizza
+import com.example.pizza_shift_2025.domain.repository.BasketRepository
+import com.example.pizza_shift_2025.domain.repository.PizzaRepository
+
+class AddPizzaToBasketUseCase (private val repository: BasketRepository) {
+    suspend operator fun invoke(pizza: Pizza) =
+        repository.addPizzaToBasket(pizza)
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/domain/usecase/GetBasketUseCase.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/domain/usecase/GetBasketUseCase.kt
@@ -1,0 +1,9 @@
+package com.example.pizza_shift_2025.domain.usecase
+
+import com.example.pizza_shift_2025.domain.entity.Pizza
+import com.example.pizza_shift_2025.domain.repository.BasketRepository
+import kotlinx.coroutines.flow.Flow
+
+class GetBasketUseCase(private val repository: BasketRepository) {
+    operator fun invoke(): Flow<List<Pizza>> = repository.getBasket()
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/presentation/navigation/MainScreen.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/presentation/navigation/MainScreen.kt
@@ -15,6 +15,8 @@ import com.example.pizza_shift_2025.presentation.ui.BasketScreen
 import com.example.pizza_shift_2025.presentation.ui.DetailScreen
 import com.example.pizza_shift_2025.presentation.ui.OrderScreen
 import com.example.pizza_shift_2025.presentation.ui.ProfileScreen
+import com.example.pizza_shift_2025.presentation.viewmodel.BasketViewModel
+import com.example.pizza_shift_2025.presentation.viewmodel.BasketViewModelFactory
 import com.example.pizza_shift_2025.presentation.viewmodel.PizzaCatalogViewModel
 import com.example.pizza_shift_2025.presentation.viewmodel.PizzaCatalogViewModelFactory
 import com.example.pizza_shift_2025.presentation.viewmodel.PizzaDetailViewModel
@@ -70,7 +72,20 @@ fun MainScreen(
             OrderScreen()
         }
         composable(Screen.BasketScreen.route) {
-            BasketScreen()
+            val viewModel: BasketViewModel = viewModel(
+                factory = BasketViewModelFactory(getPizzaCatalogUseCase)
+            )
+            BasketScreen(
+                modifier,
+                viewModel,
+                orderButtonSelected = {},
+                goToCatalogScreen = {
+                    navController.navigate(Screen.CatalogScreen.route) {
+                        popUpTo(Screen.CatalogScreen.route) {
+                            inclusive = true
+                        }
+                    }
+                })
         }
         composable(Screen.ProfileScreen.route) {
             ProfileScreen()

--- a/app/src/main/java/com/example/pizza_shift_2025/presentation/navigation/MainScreen.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/presentation/navigation/MainScreen.kt
@@ -10,6 +10,8 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import com.example.pizza_shift_2025.domain.usecase.AddPizzaToBasketUseCase
+import com.example.pizza_shift_2025.domain.usecase.GetBasketUseCase
 import com.example.pizza_shift_2025.presentation.screen.Screen
 import com.example.pizza_shift_2025.presentation.ui.BasketScreen
 import com.example.pizza_shift_2025.presentation.ui.DetailScreen
@@ -25,6 +27,8 @@ import com.example.pizza_shift_2025.presentation.viewmodel.PizzaDetailViewModelF
 @Composable
 fun MainScreen(
     getPizzaCatalogUseCase: GetPizzaCatalogUseCase,
+    getBasketUseCase: GetBasketUseCase,
+    addPizzaToBasketUseCase: AddPizzaToBasketUseCase,
     modifier: Modifier = Modifier,
     navController: NavHostController
 ) {
@@ -51,14 +55,13 @@ fun MainScreen(
             val pizzaId = backStackEntry.arguments?.getString("id") ?: return@composable
 
             val viewModel: PizzaDetailViewModel = viewModel(
-                factory = PizzaDetailViewModelFactory(getPizzaCatalogUseCase)
+                factory = PizzaDetailViewModelFactory(getPizzaCatalogUseCase, addPizzaToBasketUseCase)
             )
 
             DetailScreen(
                 modifier,
                 viewModel,
                 pizzaId,
-                onItemSelected = {},
                 goToCatalogScreen = {
                     navController.navigate(Screen.CatalogScreen.route) {
                         popUpTo(Screen.CatalogScreen.route) {
@@ -73,7 +76,7 @@ fun MainScreen(
         }
         composable(Screen.BasketScreen.route) {
             val viewModel: BasketViewModel = viewModel(
-                factory = BasketViewModelFactory(getPizzaCatalogUseCase)
+                factory = BasketViewModelFactory(getBasketUseCase)
             )
             BasketScreen(
                 modifier,

--- a/app/src/main/java/com/example/pizza_shift_2025/presentation/ui/BasketScreen.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/presentation/ui/BasketScreen.kt
@@ -47,9 +47,7 @@ fun BasketScreen(
 
 ) {
     val pizzaState by viewModel.state.collectAsState()
-    LaunchedEffect(Unit) {
-        viewModel.loadCatalog()
-    }
+
     fun onIncreasePizzaQuantity(pizzaId: String) {
 //        viewModel.increasePizzaQuantity(pizzaId)
     }

--- a/app/src/main/java/com/example/pizza_shift_2025/presentation/ui/BasketScreen.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/presentation/ui/BasketScreen.kt
@@ -1,7 +1,157 @@
 package com.example.pizza_shift_2025.presentation.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.pizza_shift_2025.R
+import com.example.pizza_shift_2025.presentation.state.PizzaCatalogState
+import com.example.pizza_shift_2025.presentation.state.PizzaDetailState
+import com.example.pizza_shift_2025.presentation.viewmodel.BasketViewModel
+import com.example.pizza_shift_2025.presentation.viewmodel.PizzaDetailViewModel
 
 @Composable
-fun BasketScreen() {
+fun BasketScreen(
+    modifier: Modifier = Modifier,
+    viewModel: BasketViewModel,
+    orderButtonSelected: () -> Unit,
+    goToCatalogScreen: () -> Unit,
+
+) {
+    val pizzaState by viewModel.state.collectAsState()
+    LaunchedEffect(Unit) {
+        viewModel.loadCatalog()
+    }
+    fun onIncreasePizzaQuantity(pizzaId: String) {
+//        viewModel.increasePizzaQuantity(pizzaId)
+    }
+
+    fun onDecreasePizzaQuantity(pizzaId: String) {
+//        viewModel.decreasePizzaQuantity(pizzaId)
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = 128.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 12.dp, horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = { goToCatalogScreen() }, modifier = Modifier.size(24.dp)) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.arrow_left),
+                        contentDescription = "Arrow Left",
+                        tint = colorResource(R.color.light_gray)
+                    )
+                }
+                Spacer(Modifier.size(32.dp))
+                Text(
+                    text = stringResource(R.string.basket),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 32.sp
+                )
+            }
+
+            when (val state = pizzaState) {
+                is PizzaCatalogState.Initial,
+                is PizzaCatalogState.Loading -> LoadingComponent()
+                is PizzaCatalogState.Content -> BasketScreenComponent (
+                    basketList = state.pizzaCatalog,
+                    onIncreasePizzaQuantity = ::onIncreasePizzaQuantity,
+                    onDecreasePizzaQuantity = ::onDecreasePizzaQuantity
+                )
+                is PizzaCatalogState.Failure -> Unit
+            }
+        }
+
+        OrderSummaryBar(
+            orderPrice = 1240,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth(),
+            orderButtonSelected
+        )
+    }
+}
+
+@Composable
+fun OrderSummaryBar(orderPrice: Int, modifier: Modifier = Modifier, orderButtonSelected: () -> Unit,) {
+    Column(
+        modifier = modifier
+            .background(Color.White)
+            .padding(16.dp)
+
+    ) {
+        Row(){
+            Text(
+                text = stringResource(R.string.order_cost),
+                modifier = Modifier.padding(bottom = 8.dp),
+                fontSize = 16.sp,
+                style = MaterialTheme.typography.labelMedium,
+                lineHeight = 24.sp,
+                fontWeight = FontWeight.W500,
+
+                )
+            Spacer(modifier = Modifier.size(24.dp))
+            Text(
+                text = stringResource(R.string.order_price, orderPrice),
+                modifier = Modifier.padding(bottom = 8.dp),
+                fontSize = 16.sp,
+                style = MaterialTheme.typography.labelMedium,
+                lineHeight = 24.sp,
+                fontWeight = FontWeight.W500,
+
+                )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(
+            onClick = { orderButtonSelected() },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            shape = RoundedCornerShape(16.dp),
+            contentPadding = PaddingValues(vertical = 16.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = colorResource(id = R.color.orange)
+            )
+        ) {
+            Text(text = stringResource(R.string.setup_order), color = Color.White, fontSize = 16.sp)
+        }
+    }
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/presentation/ui/BasketScreenComponent.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/presentation/ui/BasketScreenComponent.kt
@@ -1,0 +1,158 @@
+package com.example.pizza_shift_2025.presentation.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.rememberImagePainter
+import com.example.pizza_shift_2025.R
+import com.example.pizza_shift_2025.domain.entity.Pizza
+
+@Composable
+fun BasketScreenComponent(
+    basketList: List<Pizza>,
+    onIncreasePizzaQuantity: (String) -> Unit,
+    onDecreasePizzaQuantity: (String) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxHeight()
+    ) {
+        itemsIndexed(basketList) { index, pizza ->
+            Spacer(modifier = Modifier.size(24.dp))
+            BasketItem(
+                modifier = Modifier
+                    .clickable(enabled = false) {}
+                    .background(Color.Transparent),
+                pizza,
+                onIncreasePizzaQuantity = onIncreasePizzaQuantity,
+                onDecreasePizzaQuantity = onDecreasePizzaQuantity
+            )
+            if (index < basketList.lastIndex) {
+                Spacer(modifier = Modifier.size(24.dp))
+                Divider(
+                    color = colorResource(id = R.color.extra_light_grey),
+                    thickness = 1.dp,
+                    modifier = Modifier.padding(horizontal = 24.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun BasketItem(
+    modifier: Modifier,
+    pizza: Pizza,
+    onIncreasePizzaQuantity: (String) -> Unit,
+    onDecreasePizzaQuantity: (String) -> Unit
+) {
+    val painter = rememberImagePainter(pizza.img)
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .clickable {
+                onIncreasePizzaQuantity(pizza.id)
+            }
+    ) {
+        Image(
+            painter = painter,
+            contentDescription = "Pizza Image",
+            modifier = Modifier
+                .size(66.dp)
+                .aspectRatio(1f)
+        )
+        Spacer(modifier = Modifier.width(26.dp))
+        Column {
+            Text(
+                text = pizza.name,
+                modifier = Modifier.padding(bottom = 8.dp),
+                fontSize = 16.sp,
+                style = MaterialTheme.typography.labelMedium,
+                lineHeight = 24.sp
+            )
+            Text(
+                text = pizza.description,
+                modifier = Modifier.padding(bottom = 8.dp),
+                color = colorResource(id = R.color.gray),
+                fontSize = 12.sp,
+                lineHeight = 16.sp
+            )
+            Row(modifier = Modifier.fillMaxSize(), verticalAlignment = Alignment.CenterVertically){
+                Row(
+                    modifier = Modifier
+                        .background(
+                            color = colorResource(R.color.click_button),
+                            shape = RoundedCornerShape(14.dp)
+                        )
+                        .padding(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stringResource(R.string.minus),
+                        fontSize = 12.sp
+                    )
+
+                    Text(
+                        text = "1",
+                        fontSize = 12.sp
+                    )
+
+                    Text(
+                        text = stringResource(R.string.plus),
+                        fontSize = 12.sp
+                    )
+                }
+                Spacer(modifier = Modifier.size(16.dp))
+                Text(
+                    text = stringResource(R.string.edit),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontSize = 16.sp,
+                    lineHeight = 16.sp,
+                    textDecoration = TextDecoration.Underline,
+                    color = colorResource(id = R.color.underline_text)
+
+                )
+                Spacer(modifier = Modifier.size(32.dp))
+                Text(
+                    text = stringResource(R.string.cost, pizza.sizes[0].price),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontSize = 16.sp,
+                    lineHeight = 16.sp
+
+                )
+            }
+
+
+        }
+
+    }
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/presentation/ui/DetailScreen.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/presentation/ui/DetailScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.pizza_shift_2025.R
@@ -60,7 +61,9 @@ fun DetailScreen(
             Text(
                 text = stringResource(R.string.pizza_title),
                 style = MaterialTheme.typography.labelLarge,
-                fontSize = 24.sp
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                lineHeight = 32.sp
             )
 
         }

--- a/app/src/main/java/com/example/pizza_shift_2025/presentation/ui/DetailScreenComponent.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/presentation/ui/DetailScreenComponent.kt
@@ -76,7 +76,7 @@ fun DetailScreenComponent(
             style = MaterialTheme.typography.labelSmall
         )
         Spacer(modifier = Modifier.size(24.dp))
-        IngredientsGrid(body.ingredients)
+        IngredientsGrid(body.toppings)
     }
 }
 

--- a/app/src/main/java/com/example/pizza_shift_2025/presentation/viewmodel/BasketViewModel.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/presentation/viewmodel/BasketViewModel.kt
@@ -1,0 +1,37 @@
+package com.example.pizza_shift_2025.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.pizza_shift_2025.domain.usecase.GetPizzaCatalogUseCase
+import com.example.pizza_shift_2025.presentation.state.PizzaCatalogState
+import com.example.pizza_shift_2025.presentation.state.PizzaDetailState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
+
+class BasketViewModel(
+    private val getPizzaCatalogUseCase: GetPizzaCatalogUseCase
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<PizzaCatalogState>(PizzaCatalogState.Initial)
+    val state: StateFlow<PizzaCatalogState> = _state
+    init {
+        loadCatalog()
+    }
+
+    fun loadCatalog() {
+        viewModelScope.launch {
+            _state.value = PizzaCatalogState.Loading
+
+            try {
+                val catalog = getPizzaCatalogUseCase()
+                _state.value = PizzaCatalogState.Content(catalog)
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (ex: Exception) {
+                _state.value = PizzaCatalogState.Failure(ex.localizedMessage.orEmpty())
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/presentation/viewmodel/BasketViewModel.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/presentation/viewmodel/BasketViewModel.kt
@@ -2,36 +2,35 @@ package com.example.pizza_shift_2025.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.pizza_shift_2025.domain.usecase.GetBasketUseCase
 import com.example.pizza_shift_2025.domain.usecase.GetPizzaCatalogUseCase
 import com.example.pizza_shift_2025.presentation.state.PizzaCatalogState
 import com.example.pizza_shift_2025.presentation.state.PizzaDetailState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 
 class BasketViewModel(
-    private val getPizzaCatalogUseCase: GetPizzaCatalogUseCase
+    private val getBasketUseCase: GetBasketUseCase
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<PizzaCatalogState>(PizzaCatalogState.Initial)
-    val state: StateFlow<PizzaCatalogState> = _state
+    val state: StateFlow<PizzaCatalogState> = _state.asStateFlow()
+
     init {
         loadCatalog()
     }
 
     fun loadCatalog() {
         viewModelScope.launch {
-            _state.value = PizzaCatalogState.Loading
-
-            try {
-                val catalog = getPizzaCatalogUseCase()
-                _state.value = PizzaCatalogState.Content(catalog)
-            } catch (ce: CancellationException) {
-                throw ce
-            } catch (ex: Exception) {
-                _state.value = PizzaCatalogState.Failure(ex.localizedMessage.orEmpty())
-            }
+            getBasketUseCase()
+                .onStart { _state.value = PizzaCatalogState.Loading }
+                .catch { e -> _state.value = PizzaCatalogState.Failure(e.localizedMessage.orEmpty()) }
+                .collect { catalog -> _state.value = PizzaCatalogState.Content(catalog) }
         }
     }
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/presentation/viewmodel/BasketViewModelFactory.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/presentation/viewmodel/BasketViewModelFactory.kt
@@ -1,0 +1,15 @@
+package com.example.pizza_shift_2025.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.pizza_shift_2025.domain.usecase.GetPizzaCatalogUseCase
+
+class BasketViewModelFactory (
+    private val getPizzaCatalogUseCase: GetPizzaCatalogUseCase,
+) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        require(modelClass == BasketViewModel::class.java) { "Unknown ViewModel: $modelClass" }
+        return BasketViewModel(getPizzaCatalogUseCase) as T
+    }
+}

--- a/app/src/main/java/com/example/pizza_shift_2025/presentation/viewmodel/BasketViewModelFactory.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/presentation/viewmodel/BasketViewModelFactory.kt
@@ -2,14 +2,15 @@ package com.example.pizza_shift_2025.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.example.pizza_shift_2025.domain.usecase.GetBasketUseCase
 import com.example.pizza_shift_2025.domain.usecase.GetPizzaCatalogUseCase
 
 class BasketViewModelFactory (
-    private val getPizzaCatalogUseCase: GetPizzaCatalogUseCase,
+    private val getBasketUseCase: GetBasketUseCase,
 ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         require(modelClass == BasketViewModel::class.java) { "Unknown ViewModel: $modelClass" }
-        return BasketViewModel(getPizzaCatalogUseCase) as T
+        return BasketViewModel(getBasketUseCase) as T
     }
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/presentation/viewmodel/PizzaDetailViewModel.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/presentation/viewmodel/PizzaDetailViewModel.kt
@@ -1,7 +1,10 @@
 package com.example.pizza_shift_2025.presentation.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.pizza_shift_2025.domain.entity.Pizza
+import com.example.pizza_shift_2025.domain.usecase.AddPizzaToBasketUseCase
 import com.example.pizza_shift_2025.domain.usecase.GetPizzaCatalogUseCase
 import com.example.pizza_shift_2025.presentation.state.PizzaCatalogState
 import com.example.pizza_shift_2025.presentation.state.PizzaDetailState
@@ -11,7 +14,8 @@ import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 
 class PizzaDetailViewModel(
-    private val getPizzaCatalogUseCase: GetPizzaCatalogUseCase
+    private val getPizzaCatalogUseCase: GetPizzaCatalogUseCase,
+    private val addPizzaToBasketUseCase: AddPizzaToBasketUseCase
 ): ViewModel() {
 
     private val _state = MutableStateFlow<PizzaDetailState>(PizzaDetailState.Initial)
@@ -34,6 +38,18 @@ class PizzaDetailViewModel(
                 throw ce
             } catch (ex: Exception) {
                 _state.value = PizzaDetailState.Failure(ex.localizedMessage.orEmpty())
+            }
+        }
+    }
+    fun addToBasket(pizza: Pizza) {
+        Log.d("PizzaDetailViewModel", "addToBasket вызвана с пиццей: $pizza")
+        viewModelScope.launch {
+            try {
+                Log.d("PizzaDetailViewModel", "Запуск добавления пиццы в корзину...")
+                addPizzaToBasketUseCase(pizza)
+                Log.d("PizzaDetailViewModel", "Пицца успешно добавлена в корзину.")
+            } catch (e: Exception) {
+                Log.e("PizzaDetailViewModel", "Ошибка при добавлении пиццы в корзину: ${e.localizedMessage}")
             }
         }
     }

--- a/app/src/main/java/com/example/pizza_shift_2025/presentation/viewmodel/PizzaDetailViewModelFactory.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/presentation/viewmodel/PizzaDetailViewModelFactory.kt
@@ -3,6 +3,7 @@ package com.example.pizza_shift_2025.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.example.pizza_shift_2025.domain.usecase.AddPizzaToBasketUseCase
 import com.example.pizza_shift_2025.domain.usecase.GetPizzaCatalogUseCase
 import com.example.pizza_shift_2025.presentation.state.PizzaCatalogState
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,10 +13,11 @@ import kotlin.coroutines.cancellation.CancellationException
 
 class PizzaDetailViewModelFactory(
     private val getPizzaCatalogUseCase: GetPizzaCatalogUseCase,
+    private val addPizzaToBasketUseCase: AddPizzaToBasketUseCase
 ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         require(modelClass == PizzaDetailViewModel::class.java) { "Unknown ViewModel: $modelClass" }
-        return PizzaDetailViewModel(getPizzaCatalogUseCase) as T
+        return PizzaDetailViewModel(getPizzaCatalogUseCase, addPizzaToBasketUseCase) as T
     }
 }

--- a/app/src/main/java/com/example/pizza_shift_2025/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/pizza_shift_2025/ui/theme/Theme.kt
@@ -9,18 +9,23 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
     secondary = PurpleGrey80,
-    tertiary = Pink80
+    tertiary = Pink80,
+    background = Color.White,
+    surface = Color.White,
 )
 
 private val LightColorScheme = lightColorScheme(
     primary = Purple40,
     secondary = PurpleGrey40,
-    tertiary = Pink40
+    tertiary = Pink40,
+    background = Color.White,
+    surface = Color.White,
 
     /* Other default colors to override
     background = Color(0xFFFFFBFE),

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,4 +10,7 @@
     <color name="gray">#344051</color>
     <color name="light_gray">#CED2DA</color>
     <color name="click_button">#FFF3F4F6</color>
+    <color name="orange">#F4511E</color>
+    <color name="extra_light_grey">#E3E5E5</color>
+    <color name="underline_text">#97A1AF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,11 @@
     <string name="large">Большая</string>
     <string name="add_like_taste">Добавить по вкусу</string>
     <string name="cost">%1$s ₽</string>
+    <string name="basket">Корзина</string>
+    <string name="order_cost">Стоимость заказа:</string>
+    <string name="order_price">%1$s р</string>
+    <string name="setup_order">Оформить заказ</string>
+    <string name="minus">-</string>
+    <string name="plus">+</string>
+    <string name="edit">Изменить</string>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+kapt.incremental.apt=true
+kapt.use.worker.api=false
+org.gradle.java.home=C\:\\Program Files\\Eclipse Adoptium\\jdk-21.0.6.7-hotspot

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-agp = "8.6.1"
+agp = "8.6.0"
 
 coilCompose = "2.3.0"
-kotlin = "2.0.0"
+kotlin = "2.1.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -10,19 +10,20 @@ espressoCore = "3.6.1"
 kotlinxSerializationJson = "1.8.0"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.0"
-composeBom = "2025.01.00"
+composeBom = "2025.01.01"
 loggingInterceptor = "4.11.0"
 material3 = "1.3.1"
 navigationCompose = "2.8.6"
 okhttp = "4.11.0"
 retrofit = "2.11.0"
 retrofit2KotlinxSerializationConverter = "0.8.0"
-roomRuntime = "2.6.1"
+roomRuntime = "2.4.0-rc01"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomRuntime" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -48,4 +49,5 @@ retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,11 +17,13 @@ navigationCompose = "2.8.6"
 okhttp = "4.11.0"
 retrofit = "2.11.0"
 retrofit2KotlinxSerializationConverter = "0.8.0"
+roomRuntime = "2.6.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 28 12:19:48 GMT+07:00 2025
+#Sat Feb 01 03:38:02 GMT+07:00 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        jcenter()
+        gradlePluginPortal()
     }
 }
 


### PR DESCRIPTION
Добавил руму, пришлось решать проблемы с библиотеками (интересный кейс, почему-то не могу поставить в Dao Suspend функции https://stackoverflow.com/questions/70292474/cant-use-suspend-function-in-roomdb-dao вот здесь примерно объяснялась моя проблема)
Также  была следующая проблема примерно (решил её использованием Flow), интересно бы послушать как именно можно было решить эту проблему
Я не понимаю, насколько безопасно у меня сейчас работает Insert в Dao, учитывая что он не suspend
Проблема возникает при использовании `suspend`-методов в DAO, когда в их сигнатуре присутствует тип, требующий использования `TypeConverter`, например:  

```kotlin
@Dao
interface MyDao {
    @Query("SELECT * FROM my_table")
    suspend fun getDates(): List<Date>
}
```

При компиляции этого метода в Java его сигнатура изменяется, так как добавляется `Continuation` (необходимый для `suspend`-функций). В итоге, метод превращается во что-то вроде:  

```java
Object getDates(Continuation<? super List<? extends Date>> continuation);
```

Здесь появляется проблема: Room не может найти адаптер строк (`row adapter`) для `List<? extends Date>`, потому что `TypeConverter`, который преобразует данные в `List<Date>`, не подходит для `List<? extends Date>` (так как `List<? extends Date>` — это ковариантный тип, а `List<Date>` — инвариантный).  

Этот патч исправляет проблему, расширяя границы (`bounds`) аргумента типа `List`, чтобы Room мог корректно подобрать адаптер и выполнить преобразование данных.